### PR TITLE
Test documentation with markdown-doctest, fix typos

### DIFF
--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -1,0 +1,9 @@
+var disposables = require(__dirname);
+
+module.exports = {
+  require: {
+    'rx.disposables': disposables
+  },
+
+  globals: disposables
+}

--- a/doc/disposable.md
+++ b/doc/disposable.md
@@ -7,7 +7,7 @@ Provides a set of static methods for creating Disposables, which defines a metho
 The follow example shows the basic usage of an `Disposable`.
 
 ```js
-const d1 = Disposable.create(() => console.log('disposed'));
+const disposable = Disposable.create(() => console.log('disposed'));
 
 disposable.dispose();
 // => disposed
@@ -37,7 +37,7 @@ Creates a disposable object that invokes the specified action when disposed.
 
 #### Example
 ```js
-const d1 = Disposable.create(() => console.log('disposed'));
+const disposable = Disposable.create(() => console.log('disposed'));
 
 disposable.dispose();
 // => disposed
@@ -58,7 +58,7 @@ Creates a disposable object that invokes the specified action when disposed.
 #### Example
 ```js
 const disposable = Disposable.empty;
-console.log(disposable.isDisposable(disposable));
+console.log(Disposable.isDisposable(disposable));
 // => true
 ```
 
@@ -92,7 +92,7 @@ Performs the task of cleaning up resources.
 #### Example
 
 ```js
-const d1 = Disposable.create(() => console.log('disposed'));
+const disposable = Disposable.create(() => console.log('disposed'));
 
 disposable.dispose();
 // => disposed

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Library for Disposables which can be used independently from RxJS",
   "main": "index.js",
   "scripts": {
-    "test": "tape test/**/*.js | tap-spec"
+    "test": "tape test/**/*.js | tap-spec && markdown-doctest"
   },
   "repository": {
     "type": "git",
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/Reactive-Extensions/rx.disposables#readme",
   "devDependencies": {
+    "markdown-doctest": "^0.3.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.4.0"
   }


### PR DESCRIPTION
Heya! I was glad to see that this module had been extracted, and I thought I would try taking a crack at adding markdown-doctest support.

I have integrated it as part of the `npm test` command, so that it runs on CI and will catch any errors in the documentation in future.

There were already a few typos, and I have fixed those up.
